### PR TITLE
chore: typography 초기 세팅

### DIFF
--- a/src/components/common/Typography.tsx
+++ b/src/components/common/Typography.tsx
@@ -1,0 +1,58 @@
+import React, { ReactNode } from 'react';
+import '@/styles/Typography.scss';
+
+interface Props {
+  children: ReactNode;
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+export function Headline({
+  children,
+  className = 'headline-32-600',
+  ...props
+}: Props) {
+  return (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export function Title({
+  children,
+  className = 'title-20-600',
+  ...props
+}: Props) {
+  return (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export function Body({ children, className = 'body-14-400', ...props }: Props) {
+  return (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  );
+}
+
+export function Label({
+  children,
+  className = 'label-12-400',
+  ...props
+}: Props) {
+  return (
+    <span className={className} {...props}>
+      {children}
+    </span>
+  );
+}
+
+{
+  /* <Title className='title-14-600 subtitle'></Title>
+
+<Headline className=""></Headline> */
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,11 +1,18 @@
 import HStack from '@/components/common/Stack/HStack';
 import VStack from '@/components/common/Stack/VStack';
 import { Button } from '@/components/ui/button';
+import { Body, Headline, Label, Title } from '@/components/common/Typography';
 
 function Home() {
   return (
     <div>
-      <h1>home</h1>
+      <h1>header</h1>
+      <Headline style={{ textDecoration: 'underline' }}>
+        Hi, I am header!
+      </Headline>
+      <Title>I am Title</Title>
+      <Body className="body-14-400">I am Body</Body>
+      <Label className="label-14-400">I am Label</Label>
       <VStack gap={20}>
         <HStack justifyContent="center" alignItems="center" gap={40}>
           <div>1231231323123123</div>

--- a/src/styles/Typography.scss
+++ b/src/styles/Typography.scss
@@ -1,0 +1,87 @@
+.headline {
+  &-32 {
+    font-size: 32px;
+    line-height: 40px;
+    
+    &-600 {
+      @extend .headline-32;
+      font-weight: 600;
+    }
+  }
+
+  &-24 {
+    font-size: 24px;
+    line-height: 32px;
+    
+    &-600 {
+      @extend .headline-24;
+      font-weight: 600;
+    }
+  }
+}
+
+.title {
+  &-20 {
+    font-size: 20px;
+    line-height: 28px;
+    
+    &-600 {
+      @extend .title-20;
+      font-weight: 600;
+    }
+  }
+
+  &-14 {
+    font-size: 14px;
+    line-height: 20px;
+    
+    &-600 {
+      @extend .title-14;
+      font-weight: 600;
+    }
+  }
+}
+
+.body {
+  &-14 {
+    font-size: 14px;
+    line-height: 20px;
+    
+    &-400 {
+      @extend .body-14;
+      font-weight: 400;
+    }
+  }
+}
+
+.label {
+  &-12 {
+    font-size: 12px;
+    line-height: 16px;
+    
+    &-400 {
+      @extend .label-12;
+      font-weight: 400;
+    }
+
+    &-600 {
+      @extend .label-12;
+      font-weight: 600;
+    }
+  }
+
+  &-14 {
+    font-size: 14px;
+    line-height: 20px;
+
+    &-400 {
+      @extend .label-14;
+      font-weight: 400;
+    }
+
+    &-600 {
+      @extend .label-14;
+      font-weight: 600;
+    }
+  }
+}


### PR DESCRIPTION
* headline, title, body, label 총 4개의 종류
* span 태그를 바탕으로 제작됨
* 같은 typography 안에서 서로 다른 font-size와 font-weight를 가질 수 있음
  * 구분을 위해서 className에 ${typography 이름}-${font-size}-${font-weight} 규칙을 정하도록 함
  * 이 프로젝트에서 className을 사용하는 다른 용례가 없으므로 typography의 font style을 정하는 유일한 수단으로 className을 사용할 수 있음